### PR TITLE
处理hashmap时会因key的类型而无法通过ts类型校验

### DIFF
--- a/java/dubbo-demo/dubbo-demo-api/src/main/java/com/alibaba/dubbo/demo/UserResponse.java
+++ b/java/dubbo-demo/dubbo-demo-api/src/main/java/com/alibaba/dubbo/demo/UserResponse.java
@@ -9,6 +9,7 @@ import java.util.Map;
 public class UserResponse implements Serializable {
     private String status;
     private Map<String, String> info;
+    private Map<Long, String> orders;
 
     public String getStatus() {
         return status;
@@ -26,11 +27,20 @@ public class UserResponse implements Serializable {
         this.info = info;
     }
 
+    public Map<Long, String> getOrders() {
+        return orders;
+    }
+
+    public void setOrders(Map<Long, String> orders) {
+        this.orders = orders;
+    }
+
     @Override
     public String toString() {
         return "UserResponse{" +
                 "status='" + status + '\'' +
                 ", info=" + info +
+                ", orders=" + orders +
                 '}';
     }
 }

--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -175,7 +175,7 @@ export async function fields2CtrContent(
             paramRefName: `(mapKey as any)`,
             classPath: filedAst.typeArgs[0].type.name,
           })}, ${j2Jtj(typeOption, {
-            paramRefName: `(this.${name}[mapKey as any])`,
+            paramRefName: `this.${name}[(mapKey as any)]`,
             classPath: filedAst.typeArgs[1].type.name,
           })});
           };
@@ -193,9 +193,9 @@ export async function fields2CtrContent(
             initContent += `let ${name}MapTransfer = new Map();
           for(let mapKey  in this.${name}) {
               ${name}MapTransfer.set(${j2Jtj(typeOption, {
-              paramRefName: `mapKey`,
+              paramRefName: `(mapKey as any)`,
               classPath: filedAst.typeArgs[0].type.name,
-            })}, java.List(this.${name}[mapKey].map(paramItem=>{
+            })}, java.List(this.${name}[(mapKey as any)].map(paramItem=>{
                     return ${j2Jtj(typeOption, {
                       paramRefName: 'paramItem',
                       classPath:
@@ -248,10 +248,10 @@ export function mapParseContent(
   let initContent = `let ${resultMapName} = new Map();
           for(let mapKey  in ${mapValName}){
               ${resultMapName}.set(${j2Jtj(typeOption, {
-    paramRefName: `mapKey`,
+    paramRefName: `(mapKey as any)`,
     classPath: fieldPropers.typeArgs[0].type.name,
   })}, ${j2Jtj(typeOption, {
-    paramRefName: `${mapValName}[mapKey]`,
+    paramRefName: `${mapValName}[(mapKey as any)]`,
     classPath: fieldPropers.typeArgs[1].type.name,
   })});
           };

--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -172,10 +172,10 @@ export async function fields2CtrContent(
           initContent += `let ${name}MapTransfer = new Map();
           for(let mapKey  in this.${name}){
               ${name}MapTransfer.set(${j2Jtj(typeOption, {
-            paramRefName: `(mapKey as any)`,
+            paramRefName: `mapKey`,
             classPath: filedAst.typeArgs[0].type.name,
           })}, ${j2Jtj(typeOption, {
-            paramRefName: `this.${name}[(mapKey as any)]`,
+            paramRefName: `this.${name}[mapKey]`,
             classPath: filedAst.typeArgs[1].type.name,
           })});
           };
@@ -193,9 +193,9 @@ export async function fields2CtrContent(
             initContent += `let ${name}MapTransfer = new Map();
           for(let mapKey  in this.${name}) {
               ${name}MapTransfer.set(${j2Jtj(typeOption, {
-              paramRefName: `(mapKey as any)`,
+              paramRefName: `mapKey`,
               classPath: filedAst.typeArgs[0].type.name,
-            })}, java.List(this.${name}[(mapKey as any)].map(paramItem=>{
+            })}, java.List(this.${name}[mapKey].map(paramItem=>{
                     return ${j2Jtj(typeOption, {
                       paramRefName: 'paramItem',
                       classPath:
@@ -248,10 +248,10 @@ export function mapParseContent(
   let initContent = `let ${resultMapName} = new Map();
           for(let mapKey  in ${mapValName}){
               ${resultMapName}.set(${j2Jtj(typeOption, {
-    paramRefName: `(mapKey as any)`,
+    paramRefName: `mapKey`,
     classPath: fieldPropers.typeArgs[0].type.name,
   })}, ${j2Jtj(typeOption, {
-    paramRefName: `${mapValName}[(mapKey as any)]`,
+    paramRefName: `${mapValName}[mapKey]`,
     classPath: fieldPropers.typeArgs[1].type.name,
   })});
           };
@@ -306,6 +306,12 @@ export function j2Jtj(
     return `${paramRefName}`; //时间类型 js2java可以直接识别;
   } else if (classPath === 'java.lang.Object') {
     return `(${paramRefName}&&${paramRefName}['__fields2java'])?${paramRefName}['__fields2java']():${paramRefName}`;
+  } else if (/java\.lang\.(int|short|Short|long|Long|double|Double|float|Float)/.test(classPath)) {
+    // 如果是数字就先进行转化，然后再调用java.Float之类的方法
+    // 但是可能会出现精度问题？不确定
+    return `java.${classPath.substring(
+      classPath.lastIndexOf('.') + 1,
+    )}(Number(${paramRefName}))`;
   } else if (classPath.startsWith('java.lang.')) {
     return `java.${classPath.substring(
       classPath.lastIndexOf('.') + 1,

--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -172,10 +172,10 @@ export async function fields2CtrContent(
           initContent += `let ${name}MapTransfer = new Map();
           for(let mapKey  in this.${name}){
               ${name}MapTransfer.set(${j2Jtj(typeOption, {
-            paramRefName: `mapKey as any`,
+            paramRefName: `(mapKey as any)`,
             classPath: filedAst.typeArgs[0].type.name,
           })}, ${j2Jtj(typeOption, {
-            paramRefName: `this.${name}[mapKey as any]`,
+            paramRefName: `(this.${name}[mapKey as any])`,
             classPath: filedAst.typeArgs[1].type.name,
           })});
           };

--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -172,10 +172,10 @@ export async function fields2CtrContent(
           initContent += `let ${name}MapTransfer = new Map();
           for(let mapKey  in this.${name}){
               ${name}MapTransfer.set(${j2Jtj(typeOption, {
-            paramRefName: `mapKey`,
+            paramRefName: `mapKey as any`,
             classPath: filedAst.typeArgs[0].type.name,
           })}, ${j2Jtj(typeOption, {
-            paramRefName: `this.${name}[mapKey]`,
+            paramRefName: `this.${name}[mapKey as any]`,
             classPath: filedAst.typeArgs[1].type.name,
           })});
           };

--- a/packages/interpret-cli/src/transfer/bean/util/transfer.ts
+++ b/packages/interpret-cli/src/transfer/bean/util/transfer.ts
@@ -306,7 +306,7 @@ export function j2Jtj(
     return `${paramRefName}`; //时间类型 js2java可以直接识别;
   } else if (classPath === 'java.lang.Object') {
     return `(${paramRefName}&&${paramRefName}['__fields2java'])?${paramRefName}['__fields2java']():${paramRefName}`;
-  } else if (/java\.lang\.(int|short|Short|long|Long|double|Double|float|Float)/.test(classPath)) {
+  } else if (/java\.lang\.(int|Integer|short|Short|long|Long|double|Double|float|Float)/.test(classPath)) {
     // 如果是数字就先进行转化，然后再调用java.Float之类的方法
     // 但是可能会出现精度问题？不确定
     return `java.${classPath.substring(


### PR DESCRIPTION
如private HashMap<Long, string> ruleMap;
生成的object是以number为key，后面for in遍历时其实mapKey类型只能是string
然后就通不过ts的校验。