### PR TITLE
Make it subscribing all possible targets when set version to '*' or empty

### DIFF
--- a/packages/dubbo/src/registry/registry.ts
+++ b/packages/dubbo/src/registry/registry.ts
@@ -45,7 +45,10 @@ export default class Registry<T = {}> {
     return this._dubboServiceUrlMap
       .get(dubboInterface)
       .filter(serviceProp => {
-        const isSameVersion = serviceProp.version === version;
+        // "*" refer to default wildcard in dubbo
+        const isSameVersion = !version
+                            || version == '*' 
+                            || serviceProp.version === version;
         //如果Group为null，就默认匹配， 不检查group
         //如果Group不为null，确保group和接口的group一致
         const isSameGroup = !group || group === serviceProp.group;


### PR DESCRIPTION
Version should be an optional value and compatible with Dubbo's wildcard gramma '*'.

Reference to #126 