### PR TITLE
remove create consumer in watcher

### DIFF
--- a/packages/dubbo/src/registry/zookeeper.ts
+++ b/packages/dubbo/src/registry/zookeeper.ts
@@ -257,11 +257,6 @@ export class ZkRegistry extends Registry<IZkClientProps & IDubboRegistryProps> {
         urls.push(url);
       }
 
-      this._createConsumer({
-        name: this._props.application.name,
-        dubboInterface: dubboInterface,
-      }).then(() => log('create consumer finish'));
-
       this._dubboServiceUrlMap.set(dubboInterface, urls);
 
       if (agentAddrList.length === 0) {


### PR DESCRIPTION
consumer在init的时候已经创建了，没必要每次监听到provider变动再去尝试创建，对于Provider比较多的情况，这种会增加zk负载