### PR TITLE
fixed: support multidimensional arrays

### DIFF
--- a/packages/dubbo-serialization/src/encode-hessian2.ts
+++ b/packages/dubbo-serialization/src/encode-hessian2.ts
@@ -179,9 +179,7 @@ export class DubboRequestEncoder {
     for (let arg of args) {
       let type: string = arg['$class']
 
-      //暂时不支持二维数组
-      //如果将来支持，这个地方要while判断下
-      if (type[0] === '[') {
+      while (type[0] === '[') {
         //1. c is array
         desc.push('[')
         type = type.slice(1)


### PR DESCRIPTION
use js-to-java
```javascript
const java = require('js-to-java')
java.array('[int', [[1,2,3], [4,5,6]])


// example
{
  '$class': '[[int',
  '$': [
    { '$class': '[int', '$': [1, 2, 3] },
    { '$class': '[int', '$': [4, 5, 6] }
  ]
}

```

protocol example: [[Iint;